### PR TITLE
Fix build when the compiler is not gcc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -122,7 +122,7 @@ distclean::
 	rm -rf autom4te.cache
 
 message.o: message.c
-	gcc $(CFLAGS) $(CPPFLAGS) $(IQNFLAGS) -c -o $@ message.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(IQNFLAGS) -c -o $@ message.c
 
 $(LIB): $(LIBOBJS)
 	ar cr $@ $(LIBOBJS)
@@ -143,6 +143,6 @@ bitvector: bitvector.c $(LIB)
 	$(CC) -DTEST $(CFLAGS) -o $@ bitvector.c -L. -lisns
 
 depend:
-	gcc $(CFLAGS) -M `ls *.c` > .depend
+	$(CC) $(CFLAGS) -M `ls *.c` > .depend
 
 -include .depend


### PR DESCRIPTION
Fix Makefile.in to always $(CC) instead of gcc, to fix the compilation is made
with a different compiler (eg. when cross-compiling).

Signed-off-by: Victor Dodon dodonvictor@gmail.com
