### PR TITLE
Use /run instead of /var/run as default RUNDIR

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -141,7 +141,7 @@ clean distclean::
 	$(RM) $(TESTS)
 
 distclean::
-	rm -f config.h Makefile config.status config.log
+	rm -f config.h Makefile config.status config.log include/libisns/paths.h
 	rm -rf autom4te.cache
 
 $(filter-out solib-message.o, $(SOLIBOBJS)): $(patsubst solib-%.o,%.c,$@)

--- a/configure
+++ b/configure
@@ -621,6 +621,7 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+RUNDIR
 ENABLE_STATIC
 ENABLE_SHARED
 HAVE_LD_VERSION_SCRIPT
@@ -695,6 +696,7 @@ ac_user_opts='
 enable_option_checking
 with_security
 with_slp
+with_rundir
 enable_memdebug
 enable_shared
 enable_static
@@ -1330,6 +1332,7 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-security         Enable iSNS authentication - requires OpenSSL
   --with-slp              Enable SLP for server discovery - requires OpenSLP
+  --with-rundir=/var/run  The runtime directory for PID files etc.
 
 Some influential environment variables:
   CC          C compiler command
@@ -4399,6 +4402,21 @@ $as_echo "#define WITH_SLP 1" >>confdefs.h
 fi
 
 
+RUNDIR=/var/run
+
+# Check whether --with-rundir was given.
+if test "${with_rundir+set}" = set; then :
+  withval=$with_rundir;
+		if test "x$withval" = "xno" -o "x$withval" = "xyes"; then
+			as_fn_error $? "No rundir value specified." "$LINENO" 5
+		else
+			RUNDIR="${withval}"
+		fi
+
+
+fi
+
+
 MEMDEBUG=
 # Check whether --enable-memdebug was given.
 if test "${enable_memdebug+set}" = set; then :
@@ -4457,7 +4475,8 @@ fi
 
 
 
-ac_config_files="$ac_config_files Makefile"
+
+ac_config_files="$ac_config_files Makefile include/libisns/paths.h"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -5152,6 +5171,7 @@ do
   case $ac_config_target in
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "include/libisns/paths.h") CONFIG_FILES="$CONFIG_FILES include/libisns/paths.h" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,18 @@ if test "x$WITH_SLP" != "xno" ; then
 fi
 AC_SUBST(SLPLIBS)
 
+RUNDIR=/var/run
+AC_ARG_WITH(rundir,
+	[  --with-rundir=/var/run  The runtime directory for PID files etc.],
+	[
+		if test "x$withval" = "xno" -o "x$withval" = "xyes"; then
+			AC_MSG_ERROR([No rundir value specified.])
+		else
+			RUNDIR="${withval}"
+		fi
+	]
+)
+
 MEMDEBUG=
 AC_ARG_ENABLE(memdebug,
 	[  --enable-memdebug       Enable malloc debugging],
@@ -151,5 +163,6 @@ fi
 
 AC_SUBST(ENABLE_SHARED)
 AC_SUBST(ENABLE_STATIC)
+AC_SUBST(RUNDIR)
 
-AC_OUTPUT(Makefile)
+AC_OUTPUT(Makefile include/libisns/paths.h)

--- a/include/libisns/paths.h.in
+++ b/include/libisns/paths.h.in
@@ -13,7 +13,7 @@
 #define OPENISNS_VERSION_STRING		"0.95"
 
 #define ISNS_ETCDIR			"/etc/isns"
-#define ISNS_RUNDIR			"/var/run"
+#define ISNS_RUNDIR			"@RUNDIR@"
 #define ISNS_DEFAULT_ISNSD_CONFIG	ISNS_ETCDIR "/isnsd.conf"
 #define ISNS_DEFAULT_ISNSDD_CONFIG	ISNS_ETCDIR "/isnsdd.conf"
 #define ISNS_DEFAULT_ISNSADM_CONFIG	ISNS_ETCDIR "/isnsadm.conf"


### PR DESCRIPTION
I'm making this a separate pull request because this is something where I'm not sure you'll accept or reject. In Debian we try to only use /run, and consider /var/run to be legacy - and I believe most other distributions have similar policies. (/run has been available everywhere I know of for the last 5 years or so at the very least.) I therefore believe this is generic enough to be suitable for upstream, but it's your call.
