### PR TITLE
Support OpenSSL 1.1

### DIFF
--- a/security.c
+++ b/security.c
@@ -15,6 +15,10 @@
 
 #ifdef WITH_SECURITY
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define EVP_PKEY_base_id(o) ((o)->type)
+#endif
+
 /*
  * Allocate a security peer
  */
@@ -37,7 +41,7 @@ isns_create_principal(const char *spi, size_t spi_len, EVP_PKEY *pk)
 	if (pk) {
 		const char	*algo;
 
-		switch (pk->type) {
+		switch (EVP_PKEY_base_id(pk)) {
 		case EVP_PKEY_DSA: algo = "DSA"; break;
 		case EVP_PKEY_RSA: algo = "RSA"; break;
 		default: algo = "unknown"; break;


### PR DESCRIPTION
This pull request adds support for OpenSSL 1.1 to open-isns, while still supporting older versions. This patch has been part of the Debian package since the initial upload of open-isns to Debian over a month ago (currently still compiled against OpenSSL 1.0.2 though, as 1.1 hasn't been released yet) and there have been no reported problems. It compiles cleanly on all the platforms Debian supports, which is a lot - and on my system I've tested it (including functionality tests) against OpenSSL 1.0.1, 1.0.2 and 1.1.

It's unclear as to whether Debian will switch to OpenSSL 1.1 for its next release, but at some point all distros will upgrade; and this patch makes open-isns compile and work with all currently available versions.
