### PR TITLE
Support some operating systems other than Linux

### DIFF
--- a/include/libisns/isns.h
+++ b/include/libisns/isns.h
@@ -11,6 +11,7 @@
 #define ISNS_H
 
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <netinet/in.h>
 #include <stdio.h>
 

--- a/include/libisns/message.h
+++ b/include/libisns/message.h
@@ -13,6 +13,22 @@
 
 typedef struct isns_message_queue isns_message_queue_t;
 
+#ifdef SCM_CREDENTIALS
+/* Linux-style SCM_CREDENTIALS + struct ucred */
+typedef struct ucred    struct_cmsgcred_t;
+#define CMSGCRED_uid    uid
+#define SCM_CREDENTIALS_portable SCM_CREDENTIALS
+#elif defined(SCM_CREDS)
+/* FreeBSD-style SCM_CREDS + struct cmsgcred_t */
+typedef struct cmsgcred struct_cmsgcred_t;
+#define CMSGCRED_uid    cmcred_euid
+#define SCM_CREDENTIALS_portable SCM_CREDS
+#else
+/* If a platform requires something else, this must be added
+ * here. */
+#error "Neither SCM_CREDENTIALS nor SCM_CREDS supported on your platform for credentials passing over AF_LOCAL sockets."
+#endif
+
 struct isns_simple {
 	uint32_t		is_function;
 	isns_source_t *		is_source;
@@ -35,7 +51,7 @@ struct isns_message {
 	struct isns_buf *	im_payload;
 	isns_socket_t *		im_socket;
 	isns_principal_t *	im_security;
-	struct ucred *		im_creds;
+	struct_cmsgcred_t *	im_creds;
 
 	isns_message_queue_t *	im_queue;
 

--- a/include/libisns/util.h
+++ b/include/libisns/util.h
@@ -100,15 +100,28 @@ enum {
  * There's no htonll yet
  */
 #ifndef htonll
-# include <endian.h>
-# include <byteswap.h>
-# if __BYTE_ORDER == __BIG_ENDIAN
-#  define htonll(x)	(x)
-#  define ntohll(x)	(x)
-# elif __BYTE_ORDER == __LITTLE_ENDIAN
-#  define htonll(x)	__bswap_64(x)
-#  define ntohll(x)	__bswap_64(x)
+# ifdef __GLIBC__
+#  include <endian.h>
+#  include <byteswap.h>
+#  if __BYTE_ORDER == __BIG_ENDIAN
+#   define htonll(x)	(x)
+#   define ntohll(x)	(x)
+#  elif __BYTE_ORDER == __LITTLE_ENDIAN
+#   define htonll(x)	__bswap_64(x)
+#   define ntohll(x)	__bswap_64(x)
+#  endif
+# else
+#  include <sys/endian.h>
+#  define htonll(x)     htobe64(x)
+#  define ntohll(x)     be64toh(x)
 # endif
+#endif
+
+/*
+ * FreeBSD's libc doesn't define this for userland code
+ */
+#ifndef s6_addr32
+#define s6_addr32 __u6_addr.__u6_addr32
 #endif
 
 /*

--- a/isnsadm.c
+++ b/isnsadm.c
@@ -70,7 +70,7 @@ static int		opt_action = 0;
 static int		opt_local = 0;
 static int		opt_control = 0;
 static int		opt_replace = 0;
-static const char *	opt_keyfile = NULL;
+static char *		opt_keyfile = NULL;
 static char *		opt_key = NULL;
 static const char *	opt_servername = NULL;
 static struct sockaddr_storage opt_myaddr;
@@ -1051,9 +1051,11 @@ enroll_client(isns_client_t *clnt, int argc, char **argv)
 #endif
 
 	if (!opt_keyfile) {
-		static char 	namebuf[PATH_MAX];
-
-		snprintf(namebuf, sizeof(namebuf), "%s.key", client_name);
+		size_t capacity = strlen(client_name) + 5;
+		char *namebuf = isns_malloc(capacity);
+		if (!namebuf)
+			isns_fatal("Out of memory.");
+		snprintf(namebuf, capacity, "%s.key", client_name);
 		opt_keyfile = namebuf;
 	}
 

--- a/pki.c
+++ b/pki.c
@@ -487,19 +487,29 @@ __isns_simple_keystore_find(isns_keystore_t *store_base,
 		const char *name, size_t namelen)
 {
 	isns_simple_keystore_t *store = (isns_simple_keystore_t *) store_base;
-	char		pathname[PATH_MAX];
+	char		*pathname;
+	size_t		capacity;
+	EVP_PKEY	*result;
 
 	/* Refuse to open key files with names
 	 * that refer to parent directories */
 	if (memchr(name, '/', namelen) || name[0] == '.')
 		return NULL;
 
-	snprintf(pathname, sizeof(pathname),
+	capacity = strlen(store->sc_dirpath) + 2 + namelen;
+	pathname = isns_malloc(capacity);
+	if (!pathname)
+		isns_fatal("Out of memory.");
+	snprintf(pathname, capacity,
 			"%s/%.*s", store->sc_dirpath,
 			(int) namelen, name);
-	if (access(pathname, R_OK) < 0)
+	if (access(pathname, R_OK) < 0) {
+		isns_free(pathname);
 		return NULL;
-	return isns_dsasig_load_public_pem(NULL, pathname);
+	}
+	result = isns_dsasig_load_public_pem(NULL, pathname);
+	isns_free(pathname);
+	return result;
 }
 
 isns_keystore_t *

--- a/policy.c
+++ b/policy.c
@@ -90,7 +90,7 @@ isns_policy_bind(const isns_message_t *msg)
 
 	/* If the caller is the local root user, s/he can
 	 * do anything. */
-	if (msg->im_creds && msg->im_creds->uid == 0) {
+	if (msg->im_creds && msg->im_creds->CMSGCRED_uid == 0) {
 		policy = &isns_superhero_powers;
 		goto found;
 	}

--- a/socket.c
+++ b/socket.c
@@ -342,7 +342,7 @@ isns_pdu_authenticate(isns_security_t *sec,
 static void
 isns_pdu_enqueue(isns_socket_t *sock,
 		struct sockaddr_storage *addr, socklen_t alen,
-		buf_t *segment, struct ucred *creds)
+		buf_t *segment, struct_cmsgcred_t *creds)
 {
 	isns_message_queue_t *q = &sock->is_partial;
 	struct isns_partial_msg *msg;
@@ -594,8 +594,11 @@ void
 isns_net_stream_accept(isns_socket_t *sock)
 {
 	isns_socket_t *child;
+	int	fd;
+#ifdef SO_PASSCRED
+	int	passcred = 0;
 	socklen_t optlen;
-	int	fd, passcred = 0;
+#endif
 
 	fd = accept(sock->is_desc, NULL, NULL);
 	if (fd < 0) {
@@ -604,12 +607,14 @@ isns_net_stream_accept(isns_socket_t *sock)
 		return;
 	}
 
+#ifdef SO_PASSCRED
 	optlen = sizeof(passcred);
 	if (getsockopt(sock->is_desc, SOL_SOCKET, SO_PASSCRED,
 				&passcred, &optlen) >= 0) {
 		setsockopt(fd, SOL_SOCKET, SO_PASSCRED,
 				&passcred, sizeof(passcred));
 	}
+#endif
 
 	child = isns_net_alloc(fd);
 	child->is_type = SOCK_STREAM;
@@ -693,10 +698,10 @@ static int
 isns_net_recvmsg(isns_socket_t *sock,
 		void *buffer, size_t count,
 		struct sockaddr *addr, socklen_t *alen,
-		struct ucred **cred)
+		struct_cmsgcred_t **cred)
 {
-	static struct ucred cred_buf;
-	unsigned int	control[128];
+	static struct_cmsgcred_t cred_buf;
+	unsigned int	control[128 + sizeof(cred_buf)];
 	struct cmsghdr	*cmsg;
 	struct msghdr	msg;
 	struct iovec	iov;
@@ -723,7 +728,7 @@ isns_net_recvmsg(isns_socket_t *sock,
 	cmsg = CMSG_FIRSTHDR(&msg);
 	while (cmsg) {
 		if (cmsg->cmsg_level == SOL_SOCKET
-		 && cmsg->cmsg_type == SCM_CREDENTIALS) {
+		 && cmsg->cmsg_type == SCM_CREDENTIALS_portable) {
 			memcpy(&cred_buf, CMSG_DATA(cmsg), sizeof(cred_buf));
 			*cred = &cred_buf;
 			break;
@@ -741,7 +746,7 @@ isns_net_stream_recv(isns_socket_t *sock)
 {
 	unsigned char	buffer[ISNS_MAX_BUFFER];
 	struct sockaddr_storage addr;
-	struct ucred	*creds = NULL;
+	struct_cmsgcred_t *creds = NULL;
 	socklen_t	alen = sizeof(addr);
 	buf_t		*bp;
 	size_t		count, total = 0;
@@ -803,6 +808,41 @@ again:
 	goto again;
 }
 
+#ifndef SO_PASSCRED
+/* Without SO_PASSCRED, we need to make sure that credentials are
+ * added to all sent messages. (Otherwise recvmsg will not receive
+ * any credentials. */
+ssize_t send_with_creds(int sockfd, const void *buf, size_t len, int flags)
+{
+	unsigned char	control[CMSG_SPACE(sizeof(struct_cmsgcred_t))];
+	struct cmsghdr	*cmsg;
+	struct msghdr	msg;
+	struct iovec	iov;
+
+	iov.iov_base = (void *)buf;
+	iov.iov_len = len;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	memset(&control, 0, sizeof(control));
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_len = CMSG_LEN(sizeof(struct_cmsgcred_t));
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_CREDENTIALS_portable;
+	/* The kernel will fill the actual data structure for us, so
+	 * there's no need to bother with doing that ourselves. */
+
+	return sendmsg(sockfd, &msg, flags);
+}
+#endif
+
 void
 isns_net_stream_xmit(isns_socket_t *sock)
 {
@@ -822,7 +862,19 @@ isns_net_stream_xmit(isns_socket_t *sock)
 		return;
 
 	count = buf_avail(bp);
+#ifndef SO_PASSCRED
+	/* If SO_PASSCRED is not available, we need to ensure we add
+	 * credentials to every sent message. Only do this for AF_LOCAL
+	 * sockets though, as this won't work on AF_INET{,6}. Check
+	 * both is_src and is_dst for AF_LOCAL, because one of them
+	 * might be AF_UNSPEC. */
+	if (sock->is_dst.addr.ss_family == AF_LOCAL || sock->is_src.addr.ss_family == AF_LOCAL)
+		len = send_with_creds(sock->is_desc, buf_head(bp), count, MSG_DONTWAIT);
+	else
+		len = send(sock->is_desc, buf_head(bp), count, MSG_DONTWAIT);
+#else
 	len = send(sock->is_desc, buf_head(bp), count, MSG_DONTWAIT);
+#endif
 	if (len < 0) {
 		isns_net_stream_error(sock, errno);
 		return;
@@ -1432,6 +1484,7 @@ static int
 isns_socket_open(isns_socket_t *sock)
 {
 	int	af, fd, state = ISNS_SOCK_IDLE;
+	int	no = 0;
 
 	if (sock->is_desc >= 0)
 		return 1;
@@ -1472,16 +1525,24 @@ isns_socket_open(isns_socket_t *sock)
 		case AF_LOCAL:
 			unlink(((struct sockaddr_un *) src_addr)->sun_path);
 
+#ifdef SO_PASSCRED
 			if (sock->is_type == SOCK_STREAM
 			 && setsockopt(fd, SOL_SOCKET, SO_PASSCRED,
 				 		&on, sizeof(on)) < 0) {
 				isns_error("setsockopt(SO_PASSCRED) failed: %m\n");
 				goto failed;
 			}
+#endif
 			break;
 
-		case AF_INET:
 		case AF_INET6:
+#ifdef IPV6_V6ONLY
+			if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&no, sizeof(no))) {
+				isns_warning("setsockopt(IPV6_V6ONLY, false) failed: %m");
+			}
+#endif
+			/* no break, fall through */
+		case AF_INET:
 			if (isns_addr_get_port(src_addr) == 0) {
 				if (!__isns_socket_bind_random(fd, src_addr, src_len))
 					goto failed;

--- a/socket.h
+++ b/socket.h
@@ -20,7 +20,7 @@ struct isns_partial_msg {
 	unsigned int		imp_msg_size;
 	buf_t *			imp_chain;
 
-	struct ucred		imp_credbuf;
+	struct_cmsgcred_t	imp_credbuf;
 };
 
 #define imp_users		imp_base.im_users


### PR DESCRIPTION
There are efforts in Debian to support other kernels than Linux with the GNU userland, namely FreeBSD and GNU Hurd. This series of patches adds support for FreeBSD (both native FreeBSD and GNU/kFreeBSD) as well as Hurd to open-isns.

There are some minor differences when it comes to socket-related things in all of these operating systems, mostly related to credentials passing over `AF_LOCAL` sockets.

A variant of these patches is currently present in the packages in the Debian archive; I've cleaned those patches up and reworked them a bit - and I did functionality tests on Debian Linux, native FreeBSD, Debian GNU/kFreeBSD and Debian GNU/Hurd. The patches do not check for specific operating systems, but rather for the presence of certain constants, so this might also make open-isns work with other operating systems if they are similar to either Linux or FreeBSD in these aspects.

There's nothing that open-isns currently does that is really Linux-specific (in contrast to e.g. open-iscsi), so it would be really great if you could merge these patches. Thanks!
