### PR TITLE
Disable deprecated initializations for openssl-1.1.0

### DIFF
--- a/pki.c
+++ b/pki.c
@@ -67,7 +67,9 @@ void BN_GENCB_free(BN_GENCB *cb)
 #endif
 
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static int	isns_openssl_init = 0;
+#endif
 
 static int	isns_dsasig_verify(isns_security_t *ctx,
 				isns_principal_t *peer,
@@ -92,6 +94,7 @@ isns_create_dsa_context(void)
 {
 	isns_security_t	*ctx;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	if (!isns_openssl_init) {
 		ERR_load_crypto_strings();
 		OpenSSL_add_all_algorithms();
@@ -99,6 +102,7 @@ isns_create_dsa_context(void)
 		OpenSSL_add_all_digests();
 		isns_openssl_init = 1;
 	}
+#endif
 
 	ctx = isns_calloc(1, sizeof(*ctx));
 


### PR DESCRIPTION
This fixes several undefined reference errors when linking with
openssl-1.1.0c.

X-Gentoo-Bug: 604454
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=604454