### PR TITLE
fix include of endian.h on musl-libc based systems

### DIFF
--- a/include/libisns/util.h
+++ b/include/libisns/util.h
@@ -111,7 +111,11 @@ enum {
 #   define ntohll(x)	__bswap_64(x)
 #  endif
 # else
-#  include <sys/endian.h>
+#  if defined(__FreeBSD__)
+#   include <sys/endian.h>
+#  else
+#   include <endian.h>
+#  endif
 #  define htonll(x)     htobe64(x)
 #  define ntohll(x)     be64toh(x)
 # endif


### PR DESCRIPTION
This probably isn't the totally correct thing to do as I can't test on bsd machines, but it does fix it for musl...