### PR TITLE
DD: handle Domain ID change on creation

### DIFF
--- a/dd.c
+++ b/dd.c
@@ -1043,6 +1043,10 @@ isns_dd_add_members(isns_dd_t *dd, isns_db_t *db, isns_dd_t *new_dd)
 			isns_db_insert_limbo(db, obj);
 		mp->ddm_index = obj->ie_index;
 
+		/* Record the fact that the object is a member of
+		   this DD */
+		isns_object_mark_membership(obj, dd->dd_id);
+
 		switch (mp->ddm_type) {
 		case ISNS_DD_MEMBER_ISCSI_NODE:
 			if (isns_object_get_string(obj, ISNS_TAG_ISCSI_NAME, &node_name))


### PR DESCRIPTION
tests/test02.pl currently fails because when the Discovery Domain is
created, it's dd_id is 0. This ID is used to mark membership since
d6004b73 ('Fix DD member doubling when restoring from DB'). However,
isns_dd_insert takes a DD ID of 0 as a special case and sets it to the
next free ID (isns_dd_next_id), which starts at 1. When we iterate
through and append the temp_dd members to the actual dd object, we don't
reset the membership to be the actual DD's ID.

I noticed this fix by having test02 fail due to not seeing other members
of the DD, stopping and starting isnsd (but not deleting the database)
and then having the DD queries succeed. With this change, test02
succeeds.

This partially reverts d6004b73 ('Fix DD member doubling when restoring
from DB').