### PR TITLE
util.h: endian.h is available on musl on linux

### DIFF
--- a/include/libisns/util.h
+++ b/include/libisns/util.h
@@ -100,7 +100,7 @@ enum {
  * There's no htonll yet
  */
 #ifndef htonll
-# ifdef __GLIBC__
+# if defined(__GLIBC__) || defined(__linux__)
 #  include <endian.h>
 #  include <byteswap.h>
 #  if __BYTE_ORDER == __BIG_ENDIAN


### PR DESCRIPTION
just checking for glibc alone is not enough since
it excludes musl, therefore check for platform
being linux as well

Fixes build issues

include/libisns/util.h:114:12: fatal error: sys/endian.h: No such file or directory
 #  include <sys/endian.h>
            ^~~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>