### PR TITLE
socket.c: include poll.h instead of sys/poll.h for POSIX compatibility

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -5,7 +5,7 @@
  */
 
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 #include <sys/un.h>
 #include <string.h>


### PR DESCRIPTION
https://pubs.opengroup.org/onlinepubs/009695399/basedefs/poll.h.html

This fixes a build failure on musl libc, which has sys/poll.h that redirects to poll.h. with a \#warning 

```
$ cat /usr/include/sys/poll.h
#warning redirecting incorrect #include <sys/poll.h> to <poll.h>
#include <poll.h>
```