### PR TITLE
fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/pki.c
+++ b/pki.c
@@ -15,6 +15,8 @@
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/dsa.h>
+#include <openssl/bn.h>
 #endif
 #include <libisns/isns.h>
 #include "security.h"
@@ -97,13 +99,11 @@ isns_create_dsa_context(void)
 	isns_security_t	*ctx;
 
 	if (!isns_openssl_init) {
-		ERR_load_crypto_strings();
 #if OPENSSL_API_COMPAT < 0x10100000L
+		ERR_load_crypto_strings();
 		OpenSSL_add_all_algorithms();
 		OpenSSL_add_all_ciphers();
 		OpenSSL_add_all_digests();
-#else
-		OPENSSL_init_crypto();
 #endif
 		isns_openssl_init = 1;
 	}


### PR DESCRIPTION
Needed two missing headers and a small ifdef fix.

To test this locally, pass

CFLAGS="-Werror=implicit-function-declaration -DOPENSSL_API_COMPAT=0x10100000L"

edit: in addition, OPENSSL_init_crypto() is done internally and not needed. It's also used improperly. It requires 2 arguments, not 0.
