### PR TITLE
libisns: remove sighold and sigrelse

### DIFF
--- a/include/libisns/util.h
+++ b/include/libisns/util.h
@@ -41,14 +41,22 @@ char *		print_size(unsigned long);
  */
 static inline void signals_hold(void)
 {
-	sighold(SIGTERM);
-	sighold(SIGINT);
+	sigset_t s;
+
+	sigemptyset(&s);
+	sigaddset(&s, SIGTERM);
+	sigaddset(&s, SIGINT);
+	sigprocmask(SIG_BLOCK, &s, 0);
 }
 
 static inline void signals_release(void)
 {
-	sigrelse(SIGTERM);
-	sigrelse(SIGINT);
+	sigset_t s;
+
+	sigemptyset(&s);
+	sigaddset(&s, SIGTERM);
+	sigaddset(&s, SIGINT);
+	sigprocmask(SIG_UNBLOCK, &s, 0);
 }
 
 /*


### PR DESCRIPTION
The man page says that these are deprecated. Use sugprocmask as a replacement.