### PR TITLE
isncadm: fix parsing of GetNextRsp

### DIFF
--- a/getnext.c
+++ b/getnext.c
@@ -244,7 +244,7 @@ isns_getnext_response_get_object(isns_simple_t *qry,
 {
 	isns_object_template_t *tmpl;
 
-	tmpl = isns_object_template_for_key_attrs(&qry->is_operating_attrs);
+	tmpl = isns_object_template_for_key_attrs(&qry->is_message_attrs);
 	if (tmpl == NULL) {
 		isns_error("Cannot determine object type in GetNext response\n");
 		return ISNS_ATTRIBUTE_NOT_IMPLEMENTED;


### PR DESCRIPTION
The object template should be created based on the attributes in Message Key Attribute field instead of Operation Attribute field,
because Operation Attribute field might be empty if the client did not request the key attribute in GetNext message.

For instance, Windows 2016 iSNS server does not add any attributes by default in Operation Attributre field.
