### PR TITLE
isnsadm: Fix unparse command line options "-V" and "-r"

### DIFF
--- a/isnsadm.c
+++ b/isnsadm.c
@@ -97,7 +97,7 @@ main(int argc, char **argv)
 	isns_security_t	*security = NULL;
 	int		c, status;
 
-	while ((c = getopt_long(argc, argv, "46Cc:d:hK:k:ls:", options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "46Cc:d:hK:k:ls:Vr", options, NULL)) != -1) {
 		switch (c) {
 		case '4':
 			opt_af = AF_INET;


### PR DESCRIPTION
Following error would reported:

root@fedora:# isnsadm -V
isnsadm: invalid option -- 'V'
Error: Unknown option

root@fedora:# isnsadm -r
isnsadm: invalid option -- 'r'
Error: Unknown option

This is because we did not add "V" and "r" to parameter
when calling getopt_long()

Signed-off-by: Wenchao Hao <haowenchao@huawei.com>