### PR TITLE
Quiet a commpiler warning.

### DIFF
--- a/attrs.c
+++ b/attrs.c
@@ -777,7 +777,7 @@ isns_attr_decode(buf_t *bp, isns_attr_t **result)
 {
 	isns_attr_t	*attr = NULL;
 	isns_value_t	*value;
-	uint32_t	tag, len;
+	uint32_t	tag, len = 0;
 
 	if (!buf_get32(bp, &tag)
 	 || !buf_get32(bp, &len))


### PR DESCRIPTION
Build error looked like:

[   33s] gcc -Wall -Wextra -O2 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -Werror=return-type -flto=auto -ffat-lto-objects -g -I. -Iinclude -I. -I./include -flto=auto -ffat-lto-objects -o tests/pauw4 tests/pauw4.o -L. -lisns -Wl,--as-needed -lcrypto
[   33s] attrs.c: In function 'isns_attr_decode':
[   33s] attrs.c:807:9: warning: 'len' may be used uninitialized [-Wmaybe-uninitialized]
[   33s]   807 |         isns_error("Error decoding attribute, tag=0x%04x, len=%u\n",
[   33s]       |         ^
[   33s] attrs.c:780:30: note: 'len' declared here
[   33s]   780 |         uint32_t        tag, len;