### PR TITLE
Fix the bug in compare value

### DIFF
--- a/include/libisns/attrs.h
+++ b/include/libisns/attrs.h
@@ -7,6 +7,7 @@
 #ifndef ISNS_ATTRS_H
 #define ISNS_ATTRS_H
 
+#include <memory.h>
 #include <netinet/in.h>
 #include <libisns/buffer.h>
 #include <libisns/isns.h>
@@ -53,9 +54,13 @@ typedef struct isns_value {
 
 #define __ISNS_ATTRTYPE(type)	isns_attr_type_##type
 #define __ISNS_MEMBER(type)	iv_##type
-#define ISNS_VALUE_INIT(type, value) \
-	(isns_value_t) { .iv_type = &__ISNS_ATTRTYPE(type), \
-		         { .__ISNS_MEMBER(type) = (value) } }
+#define ISNS_VALUE_INIT(type, value) ({	\
+	isns_value_t __v;				\
+	memset(&__v, 0, sizeof(__v));		\
+	__v.iv_type = &__ISNS_ATTRTYPE(type);	\
+	__v.__ISNS_MEMBER(type) = (value);		\
+	__v;		\
+})
 
 #define isns_attr_initialize(attrp, tag, type, value) do { \
 		isns_attr_t *__attr = (attrp);		\


### PR DESCRIPTION
GCC fill zero in padding bits in struct and union are undifined behavior to C std, and clang not do this. So if we use clang to compile code, we will see the error result of comparing isns_value_t. So I fill zero in initialization of isns_value_t.